### PR TITLE
Fix install script, broken by introduction of nightly flag

### DIFF
--- a/index.sh
+++ b/index.sh
@@ -55,7 +55,7 @@ install() {
 
     # Check for install directory
 
-    if [ "$1" !=  "--nightly" ]; then
+    if [ -v 1 ] && [ "$1" !=  "--nightly" ]; then
         INSTALL_DIR="$1";
     fi
     


### PR DESCRIPTION
As of 02c1ec8bf248f4e2ec3a0b4262fb1873606aa543 the install script is broken, as it tries to dereference `$1` unconditionally even though `set -u` is enabled for the file.

This introduces a check that it's set before trying to dereference it.