### PR TITLE
Add `--interactive` flag

### DIFF
--- a/index.sh
+++ b/index.sh
@@ -20,6 +20,8 @@ BETA=false
 
 NIGHTLY=false
 
+INTERACTIVE=false
+
 INSTALL_DIR="/usr/local/bin"
 
 SURREALDB_ROOT="https://download.surrealdb.com"
@@ -60,6 +62,9 @@ install() {
             -v|--version)
                 VERSION="$2"
                 shift
+                ;;
+            -i|--interactive)
+                INTERACTIVE=true
                 ;;
             *)
                 INSTALL_DIR="$1"
@@ -214,11 +219,15 @@ install() {
     local _loc="$INSTALL_DIR"
         
     mkdir -p "$_loc" 2>/dev/null
-    
+
     if [ ! -d "$_loc" ] || ! touch "$_loc/surreal" 2>/dev/null; then
-        echo ""
-        read -p "Where would you like to install the 'surreal' binary [~/.surrealdb]? " _loc
-        _loc=${_loc:-~/.surrealdb} && _loc=$(expand "$_loc")
+        if [ "$INTERACTIVE" == true ]; then
+            echo ""
+            read -p "Where would you like to install the 'surreal' binary [~/.surrealdb]? " _loc
+            _loc=${_loc:-~/.surrealdb} && _loc=$(expand "$_loc")
+        else
+            _loc=~/.surrealdb
+        fi
         mkdir -p "$_loc"
     fi
         


### PR DESCRIPTION
`bash index.sh` now prompts for an installation directory, unlike the current

```bash
curl --proto '=https' --tlsv1.2 -sSf https://install.surrealdb.com | sh
```

This can break automatic installation scripts. This PR adds an `-i` or `--interactive` flag to invoke this behaviour so that current scripts won't be broken.