### PR TITLE
Fixes to install script path arg

### DIFF
--- a/index.sh
+++ b/index.sh
@@ -28,6 +28,8 @@ INSTALL_DIR="/usr/local/bin"
 
 SURREALDB_ROOT="https://download.surrealdb.com"
 
+WORKING_DIR=$(pwd)
+
 expand() {
     case "$1" in
     (\~)        echo "$HOME";;
@@ -73,7 +75,6 @@ install() {
                 ;;
             *)
                 INSTALL_DIR="$1"
-                shift
                 ;;
         esac
         shift
@@ -250,8 +251,10 @@ install() {
         fi
         mkdir -p "$_loc"
     fi
-        
-    mv "surreal" "$_loc" 2>/dev/null || {
+
+    cd $WORKING_DIR
+
+    mv "/tmp/surreal" "$_loc" 2>/dev/null || {
         err "Error: we couldn't install the 'surreal' binary into $_loc"
     }
     


### PR DESCRIPTION
1) An extra `shift` was added when parsing the install dir. As far as I can tell, this is only necessary when parsing args like `--version` which expect key-value pair. Because the install dir is a single arg, double-shifting results in an error

2) When specifying a local install path, the install script will install surreal within /tmp instead of the current working directory. I fixed this by updating the script to cd back to the working directory before moving surreal to its final install location

closes #15
closes #17 