### PR TITLE
let fetch<wget> write to stdout instead of file

### DIFF
--- a/index.sh
+++ b/index.sh
@@ -294,7 +294,7 @@ fetch() {
             err "$3"
         }
     elif [ "$1" = wget ]; then
-        wget --quiet "$2" || {
+        wget --quiet --output-document=- "$2" || {
             err "$3"
         }
     fi


### PR DESCRIPTION
Hi, 
I've just tried installing Surreal on a machine without cURL and noticed that the fetch() function puts the downloaded content into a file instead of returning it to the standard output stream like the script expects.